### PR TITLE
PHP 5.6+ compatibility

### DIFF
--- a/src/Asana/Dispatcher/Dispatcher.php
+++ b/src/Asana/Dispatcher/Dispatcher.php
@@ -39,9 +39,12 @@ class Dispatcher
 
                 // If the user's PHP version supports curl_file_create, use it.
                 if (function_exists('curl_file_create')) {
-                    if ( (isset($file[1]) && $file[1] != null) &&
-                         (isset($file[2]) && $file[2] != null))  {
-                        $body[$name] = curl_file_create($tmpFilePath, $file[2], $file[1]);
+                    if ( (isset($file[1]) && $file[1] != null) )  {
+                        $mimetype = '';
+                        if ( (isset($file[2]) && $file[2] != null) )  {
+                            $mimetype = $file[2];
+                        }
+                        $body[$name] = curl_file_create($tmpFilePath, $mimetype, $file[1]);
                     }
                 }
                 // Otherwise we can still use the '@' notation.

--- a/src/Asana/Dispatcher/Dispatcher.php
+++ b/src/Asana/Dispatcher/Dispatcher.php
@@ -36,12 +36,23 @@ class Dispatcher
                 $tmpFilePath = tempnam(null, null);
                 $tmpFiles[] = $tmpFilePath;
                 file_put_contents($tmpFilePath, $file[0]);
-                $body[$name] = '@' . $tmpFilePath;
-                if (isset($file[1]) && $file[1] != null) {
-                    $body[$name] .= ';filename=' . $file[1];
+
+                // If the user's PHP version supports curl_file_create, use it.
+                if (function_exists('curl_file_create')) {
+                    if ( (isset($file[1]) && $file[1] != null) &&
+                         (isset($file[2]) && $file[2] != null))  {
+                        $body[$name] = curl_file_create($tmpFilePath, $file[2], $file[1]);
+                    }
                 }
-                if (isset($file[2]) && $file[2] != null) {
-                    $body[$name] .= ';type=' . $file[2];
+                // Otherwise we can still use the '@' notation.
+                else {
+                    $body[$name] = '@' . $tmpFilePath;
+                    if (isset($file[1]) && $file[1] != null) {
+                        $body[$name] .= ';filename=' . $file[1];
+                    }
+                    if (isset($file[2]) && $file[2] != null) {
+                        $body[$name] .= ';type=' . $file[2];
+                    }
                 }
             }
             $request->body($body)->sendsType(\Httpful\Mime::UPLOAD);


### PR DESCRIPTION
As of PHP 5.6 [curl_file_create](http://php.net/manual/en/function.curl-file-create.php) should be used instead of the '@' notation.

At the moment it is not possible to upload files to asana with php 5.6+