### PR TITLE
Parse integers that are too large as strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/Asana/php-asana",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "nategood/httpful": "~0.2",
         "adoy/oauth2": "^1.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "26c7cfaad283757876b84b6239b86ce1",
+    "hash": "9a16b5d67bd631b27f415467cf62b927",
+    "content-hash": "4826f1dc5c09500ec94ad0b8fcd9ed43",
     "packages": [
         {
             "name": "adoy/oauth2",
@@ -1123,7 +1124,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.4.0"
     },
     "platform-dev": []
 }

--- a/src/Asana/Dispatcher/AccessTokenDispatcher.php
+++ b/src/Asana/Dispatcher/AccessTokenDispatcher.php
@@ -6,6 +6,8 @@ class AccessTokenDispatcher extends Dispatcher
 {
     public function __construct($accessToken)
     {
+        parent::__construct();
+
         $this->accessToken = $accessToken;
     }
 

--- a/src/Asana/Dispatcher/Dispatcher.php
+++ b/src/Asana/Dispatcher/Dispatcher.php
@@ -7,6 +7,22 @@ use \Httpful\Mime;
 
 class Dispatcher
 {
+    public function __construct()
+    {
+        // All of Asana's IDs are int64. If the current build of PHP does not
+        // support integers that large, we specify that integers that are too
+        // large should be represented as strings instead. Otherwise PHP would 
+        // convert them to floats.
+        // Note that Httpful's JsonHandler does not support that option which 
+        // is why we have to register our own JSON handler.
+        if (PHP_INT_SIZE < 8) {
+            \Httpful\Httpful::register(
+                \Httpful\Mime::JSON, 
+                new \Asana\Dispatcher\Handlers\JsonHandler(array('parse_options' => JSON_BIGINT_AS_STRING))
+            );
+        }
+    }
+
     public function request($method, $uri, $requestOptions)
     {
         if (isset($requestOptions['params'])) {

--- a/src/Asana/Dispatcher/Handlers/JsonHandler.php
+++ b/src/Asana/Dispatcher/Handlers/JsonHandler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Based on \Httpful\Handlers\JsonHandler
+ * and https://github.com/nategood/httpful/pull/189.
+ *
+ * Mime Type: application/json
+ */
+
+namespace Asana\Dispatcher\Handlers;
+
+use Httpful\Handlers\MimeHandlerAdapter;
+
+class JsonHandler extends MimeHandlerAdapter
+{
+    private $decode_as_array = false;
+    private $depth = 512;
+    private $parse_options = 0;
+
+    public function init(array $args)
+    {
+        $this->decode_as_array = !!(array_key_exists('decode_as_array', $args) ? $args['decode_as_array'] : false);
+        $this->depth = (array_key_exists('depth', $args) ? $args['depth'] : 512);
+        $this->parse_options = (array_key_exists('parse_options', $args) ? $args['parse_options'] : 0);
+    }
+
+    /**
+     * @param string $body
+     * @return mixed
+     */
+    public function parse($body)
+    {
+        $body = $this->stripBom($body);
+        if (empty($body))
+            return null;
+        $parsed = json_decode($body, $this->decode_as_array, $this->depth, $this->parse_options);
+        if (is_null($parsed) && 'null' !== strtolower($body))
+            throw new \Exception("Unable to parse response as JSON");
+        return $parsed;
+    }
+
+    /**
+     * @param mixed $payload
+     * @return string
+     */
+    public function serialize($payload)
+    {
+        return json_encode($payload);
+    }
+}

--- a/src/Asana/Dispatcher/OAuthDispatcher.php
+++ b/src/Asana/Dispatcher/OAuthDispatcher.php
@@ -15,6 +15,8 @@ class OAuthDispatcher extends Dispatcher
 
     public function __construct($options)
     {
+        parent::__construct();
+
         $this->clientId = $options['client_id'];
         $this->clientSecret = isset($options['client_secret']) ? $options['client_secret'] : null;
         $this->accessToken = isset($options['token']) ? $options['token'] : null;


### PR DESCRIPTION
This addresses https://github.com/Asana/php-asana/issues/28.

Note that the `JSON_BIGINT_AS_STRING` option was introduced with PHP 5.4.0. Refer to http://php.net/manual/en/function.json-decode.php. We therefore have to bump the required PHP version.