### PR TITLE
Use system default directory for temporary-files

### DIFF
--- a/src/Asana/Dispatcher/Dispatcher.php
+++ b/src/Asana/Dispatcher/Dispatcher.php
@@ -55,7 +55,7 @@ class Dispatcher
         $tmpFiles = array();
         if (isset($requestOptions['files'])) {
             foreach ($requestOptions['files'] as $name => $file) {
-                $tmpFilePath = tempnam(null, null);
+                $tmpFilePath = tempnam(sys_get_temp_dir(), '');
                 $tmpFiles[] = $tmpFilePath;
                 file_put_contents($tmpFilePath, $file[0]);
 


### PR DESCRIPTION
The arguments for tempnam() are not nullable. Use sys_get_temp_dir() to get the default directory for temporary files on the current system.

This is especially important if an open_basedir restriction is in effect (see https://www.php.net/manual/en/function.tempnam.php#93256).