### PR TITLE
Fix AsanaError::handleResponseError

### DIFF
--- a/src/Asana/Errors/AsanaError.php
+++ b/src/Asana/Errors/AsanaError.php
@@ -38,6 +38,10 @@ class AsanaError extends \Exception
                 throw new RateLimitEnforcedError($response);
             case ServerError::STATUS:
                 throw new ServerError($response);
+            default:
+                if ($response->code > 400) {
+                    throw new AsanaError('Asana response error', $response->code, $response);
+                }
         }
     }
 }


### PR DESCRIPTION
The PR fixes cases when server respond with, for example, 503 error, because there is no case for this code. I added default handler for all unhandled errors.
Without the fix, code continue executing and gives undefined property warning src/Asana/Client.php:103