### PR TITLE
PHP 8.1. compatibility.

### DIFF
--- a/src/Asana/Iterator/PageIterator.php
+++ b/src/Asana/Iterator/PageIterator.php
@@ -31,6 +31,7 @@ abstract class PageIterator implements \Iterator
         $this->currentPageNumber = 0;
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         # Compute the limit from the page size, and remaining item limit
@@ -48,6 +49,7 @@ abstract class PageIterator implements \Iterator
         }
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->currentPageNumber++;
@@ -66,21 +68,25 @@ abstract class PageIterator implements \Iterator
         }
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->currentPage !== null;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->currentPage;
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->currentPageNumber;
     }
 
+    #[ReturnTypeWillChange]
     public function items()
     {
         return new ItemIterator($this);


### PR DESCRIPTION
In PHP 8.1, >> non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. RFC: https://wiki.php.net/rfc/internal_method_return_types

Because of this, we receive multiple deprecation notices when running our code with PHP8.1.

This PR adds #[ReturnTypeWillChange] attribute where it is needed, in order to avoid the described problem and keep backward compatibility.