### PR TITLE
PHP 8.1. compatibility.

### DIFF
--- a/src/Asana/Iterator/ItemIterator.php
+++ b/src/Asana/Iterator/ItemIterator.php
@@ -9,6 +9,7 @@ class ItemIterator implements \Iterator
         $this->pages = $pages;
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->pages->rewind();
@@ -20,6 +21,7 @@ class ItemIterator implements \Iterator
         $this->next();
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         // if we don't have an items iterator try to get the next one
@@ -46,16 +48,19 @@ class ItemIterator implements \Iterator
         }
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->items != null;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->item;
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->itemIndex;


### PR DESCRIPTION
In PHP 8.1, >> non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. RFC: https://wiki.php.net/rfc/internal_method_return_types

Because of this, we receive multiple deprecation notices when running our code with PHP8.1.

This PR adds #[ReturnTypeWillChange] attribute where it is needed, in order to avoid the described problem and keep backward compatibility.