### PR TITLE
Add GitHub actions workflow to publish to GitHub releases

### DIFF
--- a/.github/workflows/publish-to-github-releases.yml
+++ b/.github/workflows/publish-to-github-releases.yml
@@ -1,0 +1,16 @@
+name: Publish to GitHub Releases
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-n-publish-to-github:
+    name: Publish to GitHub Releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Publish to GitHub Releases
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
- Add GitHub Actions workflow to publish to GitHub Releases on Git Tag push