### PR TITLE
Add some autocompletion sanity for intelephense

### DIFF
--- a/src/Asana/Client.php
+++ b/src/Asana/Client.php
@@ -38,6 +38,40 @@ class Client
     private static $CLIENT_OPTIONS  = null;
     private static $ALL_OPTIONS     = null;
 
+    public $dispatcher;
+    public $options;
+    public $attachments;
+    public $auditlogapi;
+    public $batchapi;
+    public $customfields;
+    public $customfieldsettings;
+    public $events;
+    public $goalrelationships;
+    public $goals;
+    public $jobs;
+    public $organizationexports;
+    public $portfolios;
+    public $projectbriefs;
+    public $portfoliomemberships;
+    public $projects;
+    public $projectmemberships;
+    public $projectstatuses;
+    public $projecttemplates;
+    public $stories;
+    public $sections;
+    public $statusupdates;
+    public $tags;
+    public $tasks;
+    public $teammemberships;
+    public $teams;
+    public $timeperiods;
+    public $typeahead;
+    public $users;
+    public $usertasklists;
+    public $webhooks;
+    public $workspacememberships;
+    public $workspaces;
+
     public function __construct($dispatcher, $options = array())
     {
         Client::bootstrap();
@@ -234,7 +268,7 @@ class Client
             }
             return $this->get($path, $query, $options);
         }
-        throw Exception('Unknown value for "iterator_type" option: ' . (string)$options['iterator_type']);
+        throw new \Exception('Unknown value for "iterator_type" option: ' . (string)$options['iterator_type']);
     }
 
     public function post($path, $data, $options = array())

--- a/src/Asana/Errors/AsanaError.php
+++ b/src/Asana/Errors/AsanaError.php
@@ -12,6 +12,10 @@ use Asana\Errors\ServerError;
 
 class AsanaError extends \Exception
 {
+    public $message;
+    public $status;
+    public $response;
+
     public function __construct($message, $status, $response)
     {
         $this->message = $message;

--- a/src/Asana/Errors/RateLimitEnforcedError.php
+++ b/src/Asana/Errors/RateLimitEnforcedError.php
@@ -9,6 +9,8 @@ class RateLimitEnforcedError extends RetryableAsanaError
     const MESSAGE = 'Rate Limit Enforced';
     const STATUS = 429;
 
+    public $retryAfter;
+
     public function __construct($response)
     {
         parent::__construct(self::MESSAGE, self::STATUS, $response);

--- a/src/Asana/Resources/Gen/SectionsBase.php
+++ b/src/Asana/Resources/Gen/SectionsBase.php
@@ -3,6 +3,7 @@
 namespace Asana\Resources\Gen;
 
 class SectionsBase {
+    public $client;
 
     /**
      * @param Asana/Client client  The client instance
@@ -17,7 +18,7 @@ class SectionsBase {
      * @param string $section_gid  (required) The globally unique identifier for the section.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function addTaskForSection($section_gid, $params = array(), $options = array()) {
         $path = "/sections/{section_gid}/addTask";
@@ -30,7 +31,7 @@ class SectionsBase {
      * @param string $project_gid  (required) Globally unique identifier for the project.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function createSectionForProject($project_gid, $params = array(), $options = array()) {
         $path = "/projects/{project_gid}/sections";
@@ -43,7 +44,7 @@ class SectionsBase {
      * @param string $section_gid  (required) The globally unique identifier for the section.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function deleteSection($section_gid, $params = array(), $options = array()) {
         $path = "/sections/{section_gid}";
@@ -56,7 +57,7 @@ class SectionsBase {
      * @param string $section_gid  (required) The globally unique identifier for the section.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function getSection($section_gid, $params = array(), $options = array()) {
         $path = "/sections/{section_gid}";
@@ -69,7 +70,7 @@ class SectionsBase {
      * @param string $project_gid  (required) Globally unique identifier for the project.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function getSectionsForProject($project_gid, $params = array(), $options = array()) {
         $path = "/projects/{project_gid}/sections";
@@ -82,7 +83,7 @@ class SectionsBase {
      * @param string $project_gid  (required) Globally unique identifier for the project.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function insertSectionForProject($project_gid, $params = array(), $options = array()) {
         $path = "/projects/{project_gid}/sections/insert";
@@ -95,7 +96,7 @@ class SectionsBase {
      * @param string $section_gid  (required) The globally unique identifier for the section.
      * @param array $params
      * @param array $options
-     * @return response
+     * @return \stdClass response
      */
     public function updateSection($section_gid, $params = array(), $options = array()) {
         $path = "/sections/{section_gid}";


### PR DESCRIPTION
Avoid having "error-hlighlight" in VSCode because attributes of "\Asana\Client" (and some other that were affecting me) are not defined in the object body as they should, this fix this issue.

Some Doc-Block have the wrong "@return" value in one of the objects.  Fixed.

Also fix a call to `throw Exception` instead of `throw new \Exception`.