### PR TITLE
Allow nategood/httpful 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "nategood/httpful": "~0.2",
+        "nategood/httpful": "~0.2 || ^1",
         "adoy/oauth2": "^1.2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b1af075a643f2ad0f3a149ec65865e9",
+    "content-hash": "cee8bfc523188b41319d4bd31a76cd1d",
     "packages": [
         {
             "name": "adoy/oauth2",
@@ -1919,5 +1919,5 @@
         "php": ">=5.4.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Fixes #123.

This library is currently vulnerable to MITM attacks because the SSL certificates of Asana's API are not verified. This is probably an accident because the underlying library `nategood/httpful` defaulted to insecure settings.

I acknowledge that this repository is somewhat in low-maintenance mode, which is why my PR follows a somewhat minimalist approach: I propose to allow the installation of version 1.0.0 of the `nategood/httpful` library which enabled SSL verification by default.